### PR TITLE
Update redis.md with redis-persistent version

### DIFF
--- a/src/configuration/services/redis.md
+++ b/src/configuration/services/redis.md
@@ -43,7 +43,7 @@ To add a Persistent Redis service, specify it in your `.platform/services.yaml` 
 
 ```yaml
 redisdata:
-    type: redis-persistent:5.0
+    type: redis-persistent:3.2
     disk: 1024
 ```
 


### PR DESCRIPTION
4.0 and 5.0 are not yet available for `redis-persistent`.